### PR TITLE
Reduce memory usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,12 @@ ARG TARGETARCH
 
 WORKDIR /go/src
 
-COPY . .
+COPY go.mod go.sum .
 
 RUN go mod download
+
+COPY . .
+
 RUN mkdir /data
 
 RUN GOOS=linux GOARCH=${TARGETARCH} go build -ldflags "-s -w" -o entropy .

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 
@@ -48,20 +49,22 @@ func (es *Entropies) Add(e Entropy) {
 	es.Lock()
 	defer es.Unlock()
 
-	entropies := es.Entropies
-	if entropies[len(entropies)-1].Entropy >= e.Entropy {
+	if es.Entropies[len(es.Entropies)-1].Entropy >= e.Entropy {
 		return
 	}
 
-	for i := range len(entropies) {
-		if entropies[i].Entropy < e.Entropy {
-			for j := len(entropies) - 1; j > i; j-- {
-				entropies[j] = entropies[j-1]
-			}
-			entropies[i] = e
-			return
+	i, _ := slices.BinarySearchFunc(es.Entropies, e, func(a, b Entropy) int {
+		if b.Entropy > a.Entropy {
+			return 1
 		}
-	}
+		if a.Entropy > b.Entropy {
+			return -1
+		}
+		return 0
+	})
+
+	copy(es.Entropies[i+1:], es.Entropies[i:])
+	es.Entropies[i] = e
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math"
 	"os"
-	"slices"
 	"strings"
 	"sync"
 
@@ -33,6 +32,29 @@ type Entropy struct {
 	File    string  // File where the line is found
 	LineNum int     // Line number in the file
 	Line    string  // Line with high entropy
+}
+
+// Entropies should be created with a size n using make()
+// it should not be written to manually, instead use Entropies.Add
+type Entropies []Entropy
+
+// Add assumes that es contains an ordered set of entropies.
+// It preserves ordering, and inserts an additional value e, if it has high enough entropy.
+// In that case, the entry with lowest entropy is rejected.
+func (es Entropies) Add(e Entropy) {
+	if es[len(es)-1].Entropy >= e.Entropy {
+		return
+	}
+
+	for i := range len(es) {
+		if es[i].Entropy < e.Entropy {
+			for j := len(es) - 1; j > i; j-- {
+				es[j] = es[j-1]
+			}
+			es[i] = e
+			return
+		}
+	}
 }
 
 func main() {
@@ -64,17 +86,14 @@ func main() {
 		fmt.Println("No files provided, defaults to current folder.")
 		fileNames = []string{"."}
 	}
-	entropies := make([]Entropy, 0, 10*len(fileNames))
+	entropies := make(Entropies, *resultCountFlag)
 	for _, fileName := range fileNames {
-		fileEntropies, err := readFile(fileName)
+		err := readFile(entropies, fileName)
 		if err != nil {
 			fmt.Println(err)
 			return
 		}
-		entropies = append(entropies, fileEntropies...)
 	}
-
-	entropies = sortAndCutTop(entropies)
 
 	redMark := "\033[31m"
 	resetMark := "\033[0m"
@@ -85,58 +104,53 @@ func main() {
 	}
 
 	for _, entropy := range entropies {
+		if entropy == (Entropy{}) {
+			return
+		}
 		fmt.Printf("%.2f: %s%s:%d%s %s\n", entropy.Entropy, redMark, entropy.File, entropy.LineNum, resetMark, entropy.Line)
 	}
 }
 
-func readFile(fileName string) ([]Entropy, error) {
+func readFile(entropies Entropies, fileName string) error {
 	// If file is a folder, walk inside the folder
 	fileInfo, err := os.Stat(fileName)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	if isFileHidden(fileInfo.Name()) && !exploreHidden {
-		return nil, nil
+		return nil
 	}
 
-	entropies := make([]Entropy, 0, 10)
 	if fileInfo.IsDir() {
 		// Walk through the folder and read all files
 		dir, err := os.ReadDir(fileName)
 		if err != nil {
-			return nil, err
+			return err
 		}
-
-		entropiies := make([][]Entropy, len(dir))
 
 		var wg sync.WaitGroup
 		for i, file := range dir {
 			wg.Add(1)
 			go func(i int, file os.DirEntry) {
 				defer wg.Done()
-				fileEntropies, err := readFile(fileName + "/" + file.Name())
+				err := readFile(entropies, fileName+"/"+file.Name())
 				if err != nil {
 					panic(err)
 				}
-				entropiies[i] = fileEntropies
 			}(i, file)
 		}
 
 		wg.Wait()
-
-		for _, fileEntropies := range entropiies {
-			entropies = append(entropies, fileEntropies...)
-		}
 	}
 
 	if !isFileIncluded(fileInfo.Name()) {
-		return sortAndCutTop(entropies), nil
+		return nil
 	}
 
 	file, err := os.Open(fileName)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer file.Close()
 
@@ -151,7 +165,7 @@ func readFile(fileName string) ([]Entropy, error) {
 				continue
 			}
 
-			entropies = append(entropies, Entropy{
+			entropies.Add(Entropy{
 				Entropy: entropy(field),
 				File:    fileName,
 				LineNum: i,
@@ -160,7 +174,7 @@ func readFile(fileName string) ([]Entropy, error) {
 		}
 	}
 
-	return sortAndCutTop(entropies), nil
+	return nil
 }
 
 func entropy(text string) float64 {
@@ -210,16 +224,4 @@ func isFileIncluded(filename string) bool {
 	}
 
 	return false
-}
-
-func sortAndCutTop(entropies []Entropy) []Entropy {
-	slices.SortFunc(entropies, func(a, b Entropy) int {
-		return int((b.Entropy - a.Entropy) * 10000)
-	})
-
-	if len(entropies) > resultCount {
-		return entropies[:resultCount]
-	}
-
-	return entropies
 }

--- a/main.go
+++ b/main.go
@@ -36,22 +36,29 @@ type Entropy struct {
 
 // Entropies should be created with a size n using make()
 // it should not be written to manually, instead use Entropies.Add
-type Entropies []Entropy
+type Entropies struct {
+	sync.Mutex
+	Entropies []Entropy
+}
 
 // Add assumes that es contains an ordered set of entropies.
 // It preserves ordering, and inserts an additional value e, if it has high enough entropy.
 // In that case, the entry with lowest entropy is rejected.
-func (es Entropies) Add(e Entropy) {
-	if es[len(es)-1].Entropy >= e.Entropy {
+func (es *Entropies) Add(e Entropy) {
+	es.Lock()
+	defer es.Unlock()
+
+	entropies := es.Entropies
+	if entropies[len(entropies)-1].Entropy >= e.Entropy {
 		return
 	}
 
-	for i := range len(es) {
-		if es[i].Entropy < e.Entropy {
-			for j := len(es) - 1; j > i; j-- {
-				es[j] = es[j-1]
+	for i := range len(entropies) {
+		if entropies[i].Entropy < e.Entropy {
+			for j := len(entropies) - 1; j > i; j-- {
+				entropies[j] = entropies[j-1]
 			}
-			es[i] = e
+			entropies[i] = e
 			return
 		}
 	}
@@ -86,7 +93,9 @@ func main() {
 		fmt.Println("No files provided, defaults to current folder.")
 		fileNames = []string{"."}
 	}
-	entropies := make(Entropies, *resultCountFlag)
+	entropies := &Entropies{
+		Entropies: make([]Entropy, resultCount),
+	}
 	for _, fileName := range fileNames {
 		err := readFile(entropies, fileName)
 		if err != nil {
@@ -103,7 +112,7 @@ func main() {
 		resetMark = ""
 	}
 
-	for _, entropy := range entropies {
+	for _, entropy := range entropies.Entropies {
 		if entropy == (Entropy{}) {
 			return
 		}
@@ -111,7 +120,7 @@ func main() {
 	}
 }
 
-func readFile(entropies Entropies, fileName string) error {
+func readFile(entropies *Entropies, fileName string) error {
 	// If file is a folder, walk inside the folder
 	fileInfo, err := os.Stat(fileName)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -3,7 +3,7 @@ package main
 import "testing"
 
 func BenchmarkFile(b *testing.B) {
-	entropies := make(Entropies, 10)
+	entropies := &Entropies{Entropies: make([]Entropy, 10)}
 	for range b.N {
 		_ = readFile(entropies, "testdata")
 	}
@@ -45,27 +45,27 @@ func TestEntropy(t *testing.T) {
 
 func TestReadFile(t *testing.T) {
 	t.Run("random.js", func(t *testing.T) {
-		res := make(Entropies, 10)
+		res := &Entropies{Entropies: make([]Entropy, 10)}
 		err := readFile(res, "testdata/random.js")
 		if err != nil {
 			t.Errorf("expected nil, got %v", err)
 		}
 
-		ExpectFloat(t, res[0].Entropy, 5.53614242151549)
-		Expect(t, res[0].LineNum, 7) // The token is hidden here
-		ExpectFloat(t, res[4].Entropy, 3.321928094887362)
+		ExpectFloat(t, res.Entropies[0].Entropy, 5.53614242151549)
+		Expect(t, res.Entropies[0].LineNum, 7) // The token is hidden here
+		ExpectFloat(t, res.Entropies[4].Entropy, 3.321928094887362)
 	})
 
 	t.Run("testdata/folder", func(t *testing.T) {
-		res := make(Entropies, 10)
+		res := &Entropies{Entropies: make([]Entropy, 10)}
 		err := readFile(res, "testdata/folder")
 		if err != nil {
 			t.Errorf("expected nil, got %v", err)
 		}
 
-		ExpectFloat(t, res[0].Entropy, 3.7667029194153567)
-		Expect(t, res[0].LineNum, 7) // The token is hidden here
-		ExpectFloat(t, res[6].Entropy, 2.8553885422075336)
+		ExpectFloat(t, res.Entropies[0].Entropy, 3.7667029194153567)
+		Expect(t, res.Entropies[0].LineNum, 7) // The token is hidden here
+		ExpectFloat(t, res.Entropies[6].Entropy, 2.8553885422075336)
 	})
 }
 
@@ -109,16 +109,16 @@ func TestIsFileHidden(t *testing.T) {
 }
 
 func TestEntropies(t *testing.T) {
-	entropies := make(Entropies, 5)
+	res := &Entropies{Entropies: make([]Entropy, 5)}
 	for _, i := range []float64{1, 3, 5, 7, 2, 4, 6, 8} {
-		entropies.Add(Entropy{Entropy: i})
+		res.Add(Entropy{Entropy: i})
 	}
 
-	Expect(t, entropies[0].Entropy, 8)
-	Expect(t, entropies[1].Entropy, 7)
-	Expect(t, entropies[2].Entropy, 6)
-	Expect(t, entropies[3].Entropy, 5)
-	Expect(t, entropies[4].Entropy, 4)
+	Expect(t, res.Entropies[0].Entropy, 8)
+	Expect(t, res.Entropies[1].Entropy, 7)
+	Expect(t, res.Entropies[2].Entropy, 6)
+	Expect(t, res.Entropies[3].Entropy, 5)
+	Expect(t, res.Entropies[4].Entropy, 4)
 }
 
 func Expect[T comparable](t *testing.T, got, expected T) {


### PR DESCRIPTION
Hi!

Hope it's cool if I made a PR, I really liked this tool but I noticed it keeps entropy information about all lines for a given file in memory and does a huge sort at the end.

## Proposed change

I propose this change, which means we never keep more lines in memory than necessary.

The `Entropies` struct keeps the top n lines sorted in a slice.

Testing with a medium sized repository, I noticed the old version got all the way up to 1G memory consumption, after the change it doesn't even show up in my top 100 memory consumption programs.

## Execution time

While I didn't see an improvement in execution time for my testing, this version does get rid of the large sort towards the end.

If we want to cut down execution time in the future, it may be wise to make an individual list per file and/or per directory (as before), and merge these together when done with each file/directory, to reduce locking on the main `Entropies` struct.

For very large values of `-top`, we could possibly also get very small performance gains using a max heap vs a slice, but that's probably premature optimization at this point.