### PR TITLE
reorder build steps to improve layer caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,12 @@ ARG TARGETARCH
 
 WORKDIR /go/src
 
-COPY . .
+COPY go.mod go.sum .
 
 RUN go mod download
+
+COPY . .
+
 RUN mkdir /data
 
 RUN GOOS=linux GOARCH=${TARGETARCH} go build -ldflags "-s -w" -o entropy .


### PR DESCRIPTION
Currently, any change in the source code requires a rerun of `go mod download`. This commit moves that step earlier so that only changes in the dependencies require a rebuild of that layer.